### PR TITLE
削除、編集時に該当idが見つからない場合のエラーを解消

### DIFF
--- a/app/Http/Controllers/DiaryRecordController.php
+++ b/app/Http/Controllers/DiaryRecordController.php
@@ -147,35 +147,41 @@ class DiaryRecordController extends Controller
         //選択した日記を取得
         $diary = Diary::find($id);
          //ログインしているユーザーを取得
-        $user = Auth::user();
-        
-        //コメントを全て取得
-        $comments  = Comments::where('diary_id', '=', $diary->id)->get();
-        //コメントのユーザー情報全てを取得
-        $comment_users = DB::table('users')->get();
 
-        $exercises = explode(",", $diary->exercise);
-        
-        //選択した日記と同じ日付の<体重>を<WeightRecord>テーブルから取得
-        $that_day_weight = WeightRecord::whereDate('created_at', $diary->created_at->format('y-m-d'))->where('user_id', $diary->user_id)->first();
-        
-        //選択した日記の日付より前で一番新しい日付の<体重>を<WeightRecord>テーブルから取得
-        $last_day_weight = WeightRecord::whereDate('created_at', '<', $diary->created_at->format('y-m-d'))
-                                ->where('user_id', $diary->user_id)
-                                ->orderBy('created_at', 'desc')
-                                ->first();
+        if(!empty($diary)) {
 
-        //上記のデータがあれば体重差を出し、なければ<-.-->を変数に代入　
-        if(!empty($last_day_weight) && !empty($that_day_weight)){
+            $user = Auth::user();
+        
+            //コメントを全て取得
+            $comments  = Comments::where('diary_id', '=', $diary->id)->get();
+            //コメントのユーザー情報全てを取得
+            $comment_users = DB::table('users')->get();
+    
+            $exercises = explode(",", $diary->exercise);
             
-            //計算結果　＝　日記の日付の体重　ー　日記の日付のひとつ前の体重
-            $result_weight = $that_day_weight->weight - $last_day_weight->weight;
-        }else{
+            //選択した日記と同じ日付の<体重>を<WeightRecord>テーブルから取得
+            $that_day_weight = WeightRecord::whereDate('created_at', $diary->created_at->format('y-m-d'))->where('user_id', $diary->user_id)->first();
             
-            $result_weight = '＜ー.ーー＞';
+            //選択した日記の日付より前で一番新しい日付の<体重>を<WeightRecord>テーブルから取得
+            $last_day_weight = WeightRecord::whereDate('created_at', '<', $diary->created_at->format('y-m-d'))
+                                    ->where('user_id', $diary->user_id)
+                                    ->orderBy('created_at', 'desc')
+                                    ->first();
+    
+            //上記のデータがあれば体重差を出し、なければ<-.-->を変数に代入　
+            if(!empty($last_day_weight) && !empty($that_day_weight)){
+                
+                //計算結果　＝　日記の日付の体重　ー　日記の日付のひとつ前の体重
+                $result_weight = $that_day_weight->weight - $last_day_weight->weight;
+            }else{
+                
+                $result_weight = '＜ー.ーー＞';
+            }
+                
+            return view('Diary.diary_show', compact('diary', 'that_day_weight', 'result_weight', 'last_day_weight', 'exercises', 'comments', 'comment_users', 'user'));
         }
-            
-        return view('Diary.diary_show', compact('diary', 'that_day_weight', 'result_weight', 'last_day_weight', 'exercises', 'comments', 'comment_users', 'user'));
+
+        return redirect()->action('DiaryRecordController@diary_history');
     }
     
     //日記編集画面の呼び出し
@@ -183,7 +189,14 @@ class DiaryRecordController extends Controller
     {   
         //選択した日記を取得
         $diary = Diary::find($id);
-        return view('Diary.diary_edit')->with('diary', $diary);
+
+        if(!empty($diary)) {
+        
+            return view('Diary.diary_edit')->with('diary', $diary);
+            
+        }
+
+        return redirect()->action('DiaryRecordController@diary_history');
     }
 
     //日記編集の処理
@@ -213,7 +226,12 @@ class DiaryRecordController extends Controller
         
         //選択したコメントを取得
         $diary = Diary::find($id);
-        $diary->delete();
+
+        if(!empty($diary)) {
+        
+            $diary->delete();
+            return redirect()->action('DiaryRecordController@diary_history');
+        }
 
         return redirect()->action('DiaryRecordController@diary_history');
     }
@@ -238,37 +256,44 @@ class DiaryRecordController extends Controller
     {
         //選択した日記を取得
         $diary = Diary::find($id);
-        //ログインしているユーザー
-        $user = Auth::user();
-        
-        //コメントを取得
-        $comments  = Comments::where('diary_id', '=', $diary->id)->get();
-        
-        //コメントしたユーザー情報を取得
-        $comment_users = DB::table('users')->get();
 
-        $exercises = explode(",", $diary->exercise);
+        if(!empty($diary)) {
         
-        //選択した日記と同じ日付の<体重>を<WeightRecord>テーブルから取得
-        $that_day_weight = WeightRecord::whereDate('created_at', $diary->created_at->format('y-m-d'))->where('user_id', $diary->user_id)->first();
-        
-        //選択した日記の日付より前で一番新しい日付の<体重>を<WeightRecord>テーブルから取得
-        $last_day_weight = WeightRecord::whereDate('created_at', '<', $diary->created_at->format('y-m-d'))
-                                ->where('user_id', $diary->user_id)
-                                ->orderBy('created_at', 'desc')
-                                ->first();
+            //ログインしているユーザー
+            $user = Auth::user();
+            
+            //コメントを取得
+            $comments  = Comments::where('diary_id', '=', $diary->id)->get();
+            
+            //コメントしたユーザー情報を取得
+            $comment_users = DB::table('users')->get();
 
-        //上記のデータがあれば体重差を出し、なければ<-.-->を変数に代入　
-        if(!empty($last_day_weight) && !empty($that_day_weight)){
+            $exercises = explode(",", $diary->exercise);
             
-            //計算結果　＝　日記の日付の体重　ー　日記の日付のひとつ前の体重
-            $result_weight = $that_day_weight->weight - $last_day_weight->weight;
-        }else{
+            //選択した日記と同じ日付の<体重>を<WeightRecord>テーブルから取得
+            $that_day_weight = WeightRecord::whereDate('created_at', $diary->created_at->format('y-m-d'))->where('user_id', $diary->user_id)->first();
             
-            $result_weight = '＜ー.ーー＞';
+            //選択した日記の日付より前で一番新しい日付の<体重>を<WeightRecord>テーブルから取得
+            $last_day_weight = WeightRecord::whereDate('created_at', '<', $diary->created_at->format('y-m-d'))
+                                    ->where('user_id', $diary->user_id)
+                                    ->orderBy('created_at', 'desc')
+                                    ->first();
+
+            //上記のデータがあれば体重差を出し、なければ<-.-->を変数に代入　
+            if(!empty($last_day_weight) && !empty($that_day_weight)){
+                
+                //計算結果　＝　日記の日付の体重　ー　日記の日付のひとつ前の体重
+                $result_weight = $that_day_weight->weight - $last_day_weight->weight;
+            }else{
+                
+                $result_weight = '＜ー.ーー＞';
+            }
+            
+            return view('Diary.friend_diary_show',compact('diary', 'that_day_weight', 'result_weight', 'last_day_weight', 'exercises', 'comments', 'comment_users', 'user'));
         }
         
-        return view('Diary.friend_diary_show',compact('diary', 'that_day_weight', 'result_weight', 'last_day_weight', 'exercises', 'comments', 'comment_users', 'user'));
+        return redirect()->action('DiaryRecordController@friend_diary');
+    
     }
     
     //コメント登録する処理
@@ -293,8 +318,13 @@ class DiaryRecordController extends Controller
 
         //選択したコメントを取得
         $comment = Comments::find($id);
+        if(!empty($comment)) {
+        
+            return view('Diary.diary_comment_edit')->with('comment', $comment);
+        
+        }
 
-        return view('Diary.diary_comment_edit')->with('comment', $comment);
+        return redirect()->action('DiaryRecordController@friend_diary');
     }
     
     //コメントを編集保存処理
@@ -316,8 +346,13 @@ class DiaryRecordController extends Controller
         
         //選択したコメントを取得
         $comment = Comments::find($id);
-        $comment->delete();
-
+        if(!empty($comment)) {
+            
+            $comment->delete();
+            return redirect()->action('DiaryRecordController@friend_diary');
+        
+        }
+    
         return redirect()->action('DiaryRecordController@friend_diary');
     }
     


### PR DESCRIPTION
・日記、コメント削除後に、一度戻り再度削除ボタンを押した場合のエラーを解消
・日記、コメント編集後に、一度戻り再度編集ボタンを押した場合のエラーを解消